### PR TITLE
fix: ordered list parsing updated

### DIFF
--- a/src/parsers/ol.ts
+++ b/src/parsers/ol.ts
@@ -1,12 +1,23 @@
 import type { ParserDef } from '../types'
 import { wrap } from '../utils'
 
+const trimItem = (x: string) => x.replace(/^\d+[.)]\s+/, '').trim()
+
 export const ol: ParserDef = {
   name: 'ol',
-  regex: /^(?<all>(?:\d.\s+[^$\n]+(?:\n|$))+)/,
-  handler: ({ all }, { parseParagraph }) =>
-    wrap(
+  regex: /(?<all>(?:\d+[.)]\s+)[\s\S]+?(?=\n\n\D|$))/,
+  handler: ({ all }, { parseParagraph }) => {
+    const parts = all.split(/\n(?=\d)/g)
+    const spacedList = parts.some((item) => item.endsWith('\n'))
+    const [first, ...rest] = parts
+    const startsWith = first.match(/^\d+/)?.[0]
+    const pWrap = spacedList
+      ? (str: string) => wrap('p', parseParagraph(str))
+      : (str: string) => parseParagraph(str)
+    return wrap(
       'ol',
-      all.split('\n').map((x) => wrap('li', parseParagraph(x.replace(/^\d+\.\s+/, '').trim())))
-    ),
+      [wrap('li', pWrap(trimItem(first))), ...rest.map((x) => wrap('li', pWrap(trimItem(x))))],
+      { start: startsWith == '1' ? null : startsWith }
+    )
+  },
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,8 +27,14 @@ export function encodeAttr(str: string): string {
   return (str + '').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 }
 
-export const wrap = (el: string, inner: string | string[]) =>
-  `<${el}>${Array.isArray(inner) ? inner.join('') : inner}</${el}>`
+export const wrap = (
+  el: string,
+  inner: string | string[],
+  attributes?: Record<string, unknown>
+) => {
+  const attrString = attributes ? attrs(attributes) : ''
+  return `<${el}${attrString}>${Array.isArray(inner) ? inner.join('') : inner}</${el}>`
+}
 
 export const parseAttrList = (str = '') => {
   const rules: string[] = []
@@ -72,7 +78,7 @@ export function* until<T>(
   }
 }
 
-export function attrs(attrs: Record<string, string>) {
+export function attrs(attrs: Record<string, unknown>) {
   const result = Object.entries(attrs)
     .filter(([k, v]) => v != null && typeof k != 'symbol')
     .map(([k, v]) => (typeof v === 'boolean' ? k : `${k}="${v}"`))
@@ -92,5 +98,5 @@ export const compileTokens = (tokens: Map<string, Omit<ParserDef, 'name'>>) => {
     )
   }
 
-  return new RegExp(regexParts.join('|'), 'gumid')
+  return new RegExp(regexParts.join('|'), 'guid')
 }

--- a/test/list.test.ts
+++ b/test/list.test.ts
@@ -25,4 +25,24 @@ describe('lists', () => {
       '<ol><li>Ordered</li><li>Lists</li><li>Numbers are ignored</li></ol>'
     )
   })
+
+  test('parses an ordered list using brackets instead of periods ', () => {
+    expect(starkdown('1) Ordered\n2) Lists\n4) Numbers are ignored')).toEqual(
+      '<ol><li>Ordered</li><li>Lists</li><li>Numbers are ignored</li></ol>'
+    )
+  })
+
+  test('parses an ordered list and starts at a different number if the first number is different ', () => {
+    expect(starkdown('5) Ordered\n2) Lists\n4) Numbers are ignored')).toEqual(
+      '<ol start="5"><li>Ordered</li><li>Lists</li><li>Numbers are ignored</li></ol>'
+    )
+  })
+
+  // Due to the way that we're dealing with newlines and paragraphs, this doesn't work at the moment but
+  // keeping this here to make sure that we can just uncomment it in the future
+  // test.only('parses an ordered list and adds paragraphs inbetween them if double spaced', () => {
+  //   expect(starkdown('1) Ordered\n2) Lists\n\n4) Numbers are ignored')).toEqual(
+  //     '<ol><li><p>Ordered<p></li><li><p>Lists<p></li><li><p>Numbers are ignored<p></li></ol>'
+  //   )
+  // })
 })


### PR DESCRIPTION
Updated Ordered lists to be a little bit better at grabbing items, following other markdown flavours. Also added code to allow for future "spaced" lists